### PR TITLE
Release the encryptionKeystore file inputStream so the operation won't lock the file. Added validations for EncryptionKeyAlias and for attachment inputs. SendMailOperation now will encript attachments too when EncryptionKeystore input is set. Added enableTLS input for send mail operation. Signed of by dan-alexandru.persa@hp.com 

### DIFF
--- a/score-mail/src/main/java/io/cloudslang/content/mail/actions/GetMailMessageAction.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/actions/GetMailMessageAction.java
@@ -139,5 +139,4 @@ public class GetMailMessageAction {
         returnResult.put(GetMailMessage.EXCEPTION, eStr);
         return returnResult;
     }
-
 }

--- a/score-mail/src/main/java/io/cloudslang/content/mail/actions/SendMailAction.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/actions/SendMailAction.java
@@ -84,7 +84,7 @@ public class SendMailAction {
             @Param(SendMailInputs.ENCRYPTION_KEYSTORE) String encryptionKeystore,
             @Param(SendMailInputs.ENCRYPTION_KEY_ALIAS) String encryptionKeyAlias,
             @Param(SendMailInputs.ENCRYPTION_KEYSTORE_PASSWORD) String encryptionKeystorePassword,
-            @Param(SendMailInputs.ENABLE_TSL) String enableTsl
+            @Param(SendMailInputs.ENABLE_TLS) String enableTLS
     ) throws Exception {
 
         SendMailInputs sendMailInputs = new SendMailInputs();
@@ -107,7 +107,7 @@ public class SendMailAction {
         sendMailInputs.setEncryptionKeystore(encryptionKeystore);
         sendMailInputs.setEncryptionKeyAlias(encryptionKeyAlias);
         sendMailInputs.setEncryptionKeystorePassword(encryptionKeystorePassword);
-        sendMailInputs.setEnableTsl(enableTsl);
+        sendMailInputs.setEnableTLS(enableTLS);
 
         try {
             return new SendMail().execute(sendMailInputs);

--- a/score-mail/src/main/java/io/cloudslang/content/mail/actions/SendMailAction.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/actions/SendMailAction.java
@@ -83,7 +83,8 @@ public class SendMailAction {
             @Param(SendMailInputs.CONTENT_TRANSFER_ENCODING) String contentTransferEncoding,
             @Param(SendMailInputs.ENCRYPTION_KEYSTORE) String encryptionKeystore,
             @Param(SendMailInputs.ENCRYPTION_KEY_ALIAS) String encryptionKeyAlias,
-            @Param(SendMailInputs.ENCRYPTION_KEYSTORE_PASSWORD) String encryptionKeystorePassword
+            @Param(SendMailInputs.ENCRYPTION_KEYSTORE_PASSWORD) String encryptionKeystorePassword,
+            @Param(SendMailInputs.ENABLE_TSL) String enableTsl
     ) throws Exception {
 
         SendMailInputs sendMailInputs = new SendMailInputs();
@@ -106,6 +107,7 @@ public class SendMailAction {
         sendMailInputs.setEncryptionKeystore(encryptionKeystore);
         sendMailInputs.setEncryptionKeyAlias(encryptionKeyAlias);
         sendMailInputs.setEncryptionKeystorePassword(encryptionKeystorePassword);
+        sendMailInputs.setEnableTsl(enableTsl);
 
         try {
             return new SendMail().execute(sendMailInputs);

--- a/score-mail/src/main/java/io/cloudslang/content/mail/entities/SendMailInputs.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/entities/SendMailInputs.java
@@ -24,6 +24,7 @@ public class SendMailInputs {
     public static final String ENCRYPTION_KEYSTORE = "encryptionKeystore";
     public static final String ENCRYPTION_KEY_ALIAS = "encryptionKeyAlias";
     public static final String ENCRYPTION_KEYSTORE_PASSWORD = "encryptionKeystorePassword";
+    public static final String ENABLE_TSL = "enableTSL";
 
     private String smtpHostname;
     private String port;
@@ -44,6 +45,7 @@ public class SendMailInputs {
     private String encryptionKeystore;
     private String encryptionKeyAlias;
     private String encryptionKeystorePassword;
+    private String enableTsl;
 
     public String getSMTPHostname() {
         return smtpHostname;
@@ -195,5 +197,13 @@ public class SendMailInputs {
 
     public void setEncryptionKeystorePassword(String encryptionKeystorePassword) {
         this.encryptionKeystorePassword = encryptionKeystorePassword;
+    }
+
+    public String getEnableTsl() {
+        return enableTsl;
+    }
+
+    public void setEnableTsl(String enableTsl) {
+        this.enableTsl = enableTsl;
     }
 }

--- a/score-mail/src/main/java/io/cloudslang/content/mail/entities/SendMailInputs.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/entities/SendMailInputs.java
@@ -24,7 +24,7 @@ public class SendMailInputs {
     public static final String ENCRYPTION_KEYSTORE = "encryptionKeystore";
     public static final String ENCRYPTION_KEY_ALIAS = "encryptionKeyAlias";
     public static final String ENCRYPTION_KEYSTORE_PASSWORD = "encryptionKeystorePassword";
-    public static final String ENABLE_TSL = "enableTSL";
+    public static final String ENABLE_TLS = "enableTLS";
 
     private String smtpHostname;
     private String port;
@@ -45,7 +45,7 @@ public class SendMailInputs {
     private String encryptionKeystore;
     private String encryptionKeyAlias;
     private String encryptionKeystorePassword;
-    private String enableTsl;
+    private String enableTLS;
 
     public String getSMTPHostname() {
         return smtpHostname;
@@ -199,11 +199,11 @@ public class SendMailInputs {
         this.encryptionKeystorePassword = encryptionKeystorePassword;
     }
 
-    public String getEnableTsl() {
-        return enableTsl;
+    public String getEnableTLS() {
+        return enableTLS;
     }
 
-    public void setEnableTsl(String enableTsl) {
-        this.enableTsl = enableTsl;
+    public void setEnableTLS(String enableTLS) {
+        this.enableTLS = enableTLS;
     }
 }

--- a/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
@@ -6,7 +6,6 @@ import com.sun.mail.smtp.SMTPMessage;
 import io.cloudslang.content.mail.entities.SendMailInputs;
 
 import javax.activation.DataHandler;
-import javax.activation.DataSource;
 import javax.activation.FileDataSource;
 import javax.mail.*;
 import javax.mail.internet.*;
@@ -66,6 +65,7 @@ public class SendMail {
     boolean html;
     boolean readReceipt;
     boolean encryptMessage;
+    boolean enableTsl;
     SMIMEEnvelopedGenerator gen;
 
     public Map<String, String> execute(SendMailInputs sendMailInputs) throws Exception {
@@ -85,6 +85,9 @@ public class SendMail {
                 props.put("mail.smtp.user", user);
                 props.put("mail.smtp.password", password);
                 props.put("mail.smtp.auth", "true");
+            }
+            if(enableTsl) {
+                props.put("mail.smtp.starttls.enable", "true");
             }
 
             Session session = Session.getInstance(props, null);
@@ -296,6 +299,12 @@ public class SendMail {
             }
         } else {
             encryptMessage = false;
+        }
+
+        try {
+            enableTsl = Boolean.parseBoolean(sendMailInputs.getEnableTsl());
+        } catch (Exception e) {
+            enableTsl = false;
         }
     }
 }

--- a/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
@@ -183,7 +183,7 @@ public class SendMail {
         return result;
     }
 
-    protected void addEncryptionSettings() throws  Exception{
+    private void addEncryptionSettings() throws  Exception{
         URL keystoreUrl = new URL(keystoreFile);
         InputStream publicKeystoreInputStream = keystoreUrl.openStream();
         char[] smimePw = new String(keystorePass).toCharArray();
@@ -192,7 +192,11 @@ public class SendMail {
         gen = new SMIMEEnvelopedGenerator();
         Security.addProvider(new BouncyCastleProvider());
         KeyStore ks = KeyStore.getInstance(PKCS_KEYSTORE_TYPE, BOUNCY_CASTLE_PROVIDER);
-        ks.load(publicKeystoreInputStream, smimePw);
+        try {
+            ks.load(publicKeystoreInputStream, smimePw);
+        } finally {
+            publicKeystoreInputStream.close();
+        }
 
         if(keyAlias.equals("")) {
             Enumeration e = ks.aliases();

--- a/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
@@ -114,7 +114,7 @@ public class SendMail {
                 for (String attachment : attachments.split(Pattern.quote(delimiter))) {
                     FileDataSource source = new FileDataSource(attachment);
                     if(!source.getFile().exists()) {
-                        throw new FileNotFoundException(attachment + " can't be found");
+                        throw new FileNotFoundException("Cannot attach " + attachment);
                     }
 
                     MimeBodyPart messageBodyPart = new MimeBodyPart();

--- a/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
+++ b/score-mail/src/main/java/io/cloudslang/content/mail/services/SendMail.java
@@ -65,7 +65,7 @@ public class SendMail {
     boolean html;
     boolean readReceipt;
     boolean encryptMessage;
-    boolean enableTsl;
+    boolean enableTLS;
     SMIMEEnvelopedGenerator gen;
 
     public Map<String, String> execute(SendMailInputs sendMailInputs) throws Exception {
@@ -86,7 +86,7 @@ public class SendMail {
                 props.put("mail.smtp.password", password);
                 props.put("mail.smtp.auth", "true");
             }
-            if(enableTsl) {
+            if(enableTLS) {
                 props.put("mail.smtp.starttls.enable", "true");
             }
 
@@ -302,9 +302,9 @@ public class SendMail {
         }
 
         try {
-            enableTsl = Boolean.parseBoolean(sendMailInputs.getEnableTsl());
+            enableTLS = Boolean.parseBoolean(sendMailInputs.getEnableTLS());
         } catch (Exception e) {
-            enableTsl = false;
+            enableTLS = false;
         }
     }
 }

--- a/score-mail/src/test/java/io/cloudslang/content/mail/services/SendMailTest.java
+++ b/score-mail/src/test/java/io/cloudslang/content/mail/services/SendMailTest.java
@@ -21,6 +21,7 @@ import javax.mail.*;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMultipart;
+import java.io.File;
 import java.util.Map;
 import java.util.Properties;
 
@@ -107,6 +108,8 @@ public class SendMailTest {
     private FileDataSource fileDataSourceMock;
     @Mock
     private DataHandler dataHandlerMock;
+    @Mock
+    private File fileMock;
 
     /**
      * Initialize tested object and set up the mocks.
@@ -237,6 +240,8 @@ public class SendMailTest {
         prepareTransportClassForStaticMock();
         Mockito.doNothing().when(mimeBodyPartMock).setContent(BODY, TEXT_PLAIN + CHARSET_CST + DEFAULT_CHARACTERSET);
         PowerMockito.whenNew(FileDataSource.class).withArguments(anyString()).thenReturn(fileDataSourceMock);
+        Mockito.doReturn(fileMock).when(fileDataSourceMock).getFile();
+        Mockito.doReturn(true).when(fileMock).exists();
         PowerMockito.whenNew(DataHandler.class).withArguments(fileDataSourceMock).thenReturn(dataHandlerMock);
         doNothing().when(mimeBodyPartMock).setDataHandler(dataHandlerMock);
         doNothing().when(mimeBodyPartMock).setFileName(anyString());
@@ -331,6 +336,8 @@ public class SendMailTest {
 
         Mockito.doNothing().when(mimeBodyPartMock).setContent(BODY, TEXT_PLAIN + CHARSET_CST + DEFAULT_CHARACTERSET);
         PowerMockito.whenNew(FileDataSource.class).withArguments(anyString()).thenReturn(fileDataSourceMock);
+        Mockito.doReturn(fileMock).when(fileDataSourceMock).getFile();
+        Mockito.doReturn(false).when(fileMock).exists();
         PowerMockito.whenNew(DataHandler.class).withArguments(fileDataSourceMock).thenReturn(dataHandlerMock);
         doNothing().when(mimeBodyPartMock).setDataHandler(dataHandlerMock);
 


### PR DESCRIPTION
Added some extra negative scenarios validations.