### PR TITLE
Discovered and fixed a defect

### DIFF
--- a/score-data-format/src/main/java/io/cloudslang/content/json/services/JsonService.java
+++ b/score-data-format/src/main/java/io/cloudslang/content/json/services/JsonService.java
@@ -42,7 +42,7 @@ public class JsonService {
         JSONObject jsonObject = new JSONObject(jsonMap);
         String newJson = jsonObject.toJSONString(JSONStyle.LT_COMPRESS);
 
-        if (newJson.charAt(1) != wrappingQuote) {
+        if ((!jsonObject.isEmpty()) && (newJson.charAt(1) != wrappingQuote)) {
             return replaceUnescapedOccurrencesOfCharacterInText(newJson, newJson.charAt(1), wrappingQuote);
         }
 

--- a/score-data-format/src/test/java/io/cloudslang/content/json/services/JsonServiceTest.java
+++ b/score-data-format/src/test/java/io/cloudslang/content/json/services/JsonServiceTest.java
@@ -173,4 +173,13 @@ public class JsonServiceTest {
         exception.expect(RemoveEmptyElementException.class);
         actualJsonStringOutput = jsonServiceUnderTest.removeEmptyElementsJson(jsonStringInput);
     }
+
+    @Test
+    public void givenJsonWithEmptyElementsThenReturnEmptyJsonString() throws RemoveEmptyElementException {
+        jsonStringInput = "{'remove1': '','remove2': ''}";
+        expectedJsonStringOutput ="{}";
+        actualJsonStringOutput = jsonServiceUnderTest.removeEmptyElementsJson(jsonStringInput);
+
+        assertEquals(expectedJsonStringOutput,actualJsonStringOutput);
+    }
 }


### PR DESCRIPTION
Discovered a problem which occurred when the input value was a json in which all the elements were empty and the resulting json was an empty json however the string representation was invalid.

Signed-off-by: Bogdan Nane<bogdan.nane@hpe.com>