### PR TITLE
Fix authentication types check when provided as list.

### DIFF
--- a/score-http-client/src/main/java/io/cloudslang/content/httpclient/build/auth/AuthTypes.java
+++ b/score-http-client/src/main/java/io/cloudslang/content/httpclient/build/auth/AuthTypes.java
@@ -39,6 +39,7 @@ public class AuthTypes implements Iterable<String> {
         supportedAuthTypes.add(DIGEST);
         supportedAuthTypes.add(NTLM);
         supportedAuthTypes.add(KERBEROS);
+        supportedAuthTypes.add(ANONYMOUS);
     }
 
     private Set<String> authTypes = new HashSet();
@@ -71,8 +72,6 @@ public class AuthTypes implements Iterable<String> {
 
         if (authType.equalsIgnoreCase(ANY)) {
             authTypes.addAll(supportedAuthTypes);
-        } else if (authType.equalsIgnoreCase(ANONYMOUS)) {
-            add(ANONYMOUS);
         } else {
             String[] toks = authType.split(",");
             for (String tok : toks) {


### PR DESCRIPTION
When providing multiple auth types separated by comma, the anonymous type is not accepted because the check is not done correctly when having multiple auth types.