### PR TITLE
Fix multipartFilesContentType input name.

### DIFF
--- a/score-http-client/src/main/java/io/cloudslang/content/httpclient/HttpClientInputs.java
+++ b/score-http-client/src/main/java/io/cloudslang/content/httpclient/HttpClientInputs.java
@@ -60,7 +60,7 @@ public class HttpClientInputs {
     public static final String MULTIPART_BODIES = "multipartBodies";
     public static final String MULTIPART_BODIES_CONTENT_TYPE = "multipartBodiesContentType";
     public static final String MULTIPART_FILES = "multipartFiles";
-    public static final String MULTIPART_FILES_CONTENT_TYPE = "multipartBodiesContentType";
+    public static final String MULTIPART_FILES_CONTENT_TYPE = "multipartFilesContentType";
     public static final String MULTIPART_VALUES_ARE_URLENCODED = "multipartValuesAreURLEncoded";
     public static final String CHUNKED_REQUEST_ENTITY = "chunkedRequestEntity";
 


### PR DESCRIPTION
Was previously set to multipartBodiesContentType making the @param
redundant and causing the @action to incorrectly import into HPE OO Studio
w/o the multipartFilesContentType input.