### PR TITLE
Remove commandTimeout mechanism when pty is set to true. Issue#125

### DIFF
--- a/score-ssh/src/main/java/io/cloudslang/content/ssh/services/impl/SSHServiceImpl.java
+++ b/score-ssh/src/main/java/io/cloudslang/content/ssh/services/impl/SSHServiceImpl.java
@@ -159,7 +159,7 @@ public class SSHServiceImpl implements SSHService {
             // The exit status is only available after the channel was closed (more exactly, just before the channel is closed).
             result.setExitCode(channel.getExitStatus());
 
-            if (timedOut) {
+            if (timedOut && !usePseudoTerminal) {
                 throw new TimeoutException(String.valueOf(result));
             }
 

--- a/score-ssh/src/test/java/io/cloudslang/content/ssh/services/impl/SSHServiceImplTest.java
+++ b/score-ssh/src/test/java/io/cloudslang/content/ssh/services/impl/SSHServiceImplTest.java
@@ -170,16 +170,4 @@ public class SSHServiceImplTest {
         SSHService sshService = new SSHServiceImpl(sessionMock, channelShellMock);
         sshService.removeFromCache(Mockito.any(GlobalSessionObject.class), "sessionId");
     }
-
-    @Test
-    public void testTimeoutExceptionIsThrown() throws Exception {
-        PowerMockito.when(channelShellMock.isClosed()).thenReturn(false);
-        SSHService sshService = new SSHServiceImpl(sessionMock, channelShellMock);
-
-        exception.expect(RuntimeException.class);
-        exception.expectMessage("Timeout");
-
-        sshService.runShellCommand("ls", "UTF-8", true, CONNECT_TIMEOUT, 0, AGENT_FORWARDING_FALSE);
-    }
-
 }


### PR DESCRIPTION
Remove commandTimeout mechanism when pty is set to true. When pty is true the channel remains opened until you disconnect it, so a timeout mechanism based on whether the channel is closed or not will not work.

Related issue: https://github.com/CloudSlang/score-actions/issues/125

Signed-off-by: George Giloan <giloan@hpe.com>